### PR TITLE
feat: Create Neovim plugin to show variable type

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 {
-  'your-github-username/show-type.nvim',
+  'sim-maz/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -25,7 +25,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ```lua
 use {
-  'your-github-username/show-type.nvim',
+  'sim-maz/show-type.nvim',
   config = function()
     require('show_type').setup()
   end
@@ -35,7 +35,7 @@ use {
 ### [vim-plug](https://github.com/junegunn/vim-plug)
 
 ```vim
-Plug 'your-github-username/show-type.nvim'
+Plug 'sim-maz/show-type.nvim'
 ```
 
 Then, in your `init.lua` or somewhere after the plugin is loaded:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 ## Installation
 
+### [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+{
+  'your-github-username/show-type.nvim',
+  config = function()
+    require('show_type').setup()
+  end
+}
+```
+
 ### [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 ```lua


### PR DESCRIPTION
This commit introduces a new Neovim plugin, `show-type.nvim`, that displays the type of the variable under the cursor in a notification.

The plugin uses the built-in LSP client to get type information by temporarily overriding the `textDocument/hover` handler. This allows it to capture the type information without showing the hover popup.

Features:
- `:ShowType` command to display the type.
- Configurable notification system, allowing integration with plugins like `mini.notify`.
- Simple and lightweight, with no external dependencies.

docs: Add installation instructions for lazy.nvim