### PR TITLE
feat: Add support for nvim-notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 
 - Shows the type of the variable under the cursor using LSP.
 - Displays the type in a notification.
-- Pluggable notification system, compatible with `vim.notify` and `mini.notify`.
+- Pluggable notification system, compatible with `vim.notify`, `mini.notify`, and `nvim-notify`.
 
 ## Installation
 
@@ -15,9 +15,7 @@ A simple Neovim plugin to show the type of the variable under the cursor in a no
 ```lua
 {
   'sim-maz/show-type.nvim',
-  config = function()
-    require('show_type').setup()
-  end
+  opts = {} -- Or your configuration table
 }
 ```
 
@@ -37,7 +35,6 @@ use {
 ```vim
 Plug 'sim-maz/show-type.nvim'
 ```
-
 Then, in your `init.lua` or somewhere after the plugin is loaded:
 ```lua
 require('show_type').setup()
@@ -45,49 +42,57 @@ require('show_type').setup()
 
 ## Configuration
 
-The `setup` function accepts a configuration table. The following options are available:
+The `setup` function accepts a configuration table.
 
-- `notify_func`: A function that takes a message string and displays it as a notification. Defaults to `vim.notify`.
+### Options
 
-### Example with `mini.notify`
+- `notification_provider` (string): The notification provider to use.
+  - `'default'`: Uses the built-in `vim.notify`. This is the default.
+  - `'mini.notify'`: Uses `mini.notify`. Requires `mini.nvim` to be installed.
+  - `'nvim-notify'`: Uses `rcarriga/nvim-notify`. Requires the plugin to be installed.
 
-To use `mini.notify`, you can provide a custom `notify_func` in the `setup` call. The following example shows the correct way to do this, including the necessary checks to ensure `mini.notify` is ready to be used.
+- `notify_func` (function): For advanced customization, you can provide your own notification function. If this is provided, it will override `notification_provider`.
 
-```lua
-require('show_type').setup({
-  notify_func = function(msg)
-    if _G.MiniNotify and _G.MiniNotify.make_notify then
-      local notify = _G.MiniNotify.make_notify()
-      notify(msg, vim.log.levels.INFO, { title = 'Type', timeout = 5000 })
-    else
-      vim.notify(msg, vim.log.levels.INFO, { title = 'Type' })
-    end
-  end
-})
-```
+### Examples
 
-**Important Note for `lazy.nvim` users:**
-If you use `lazy.nvim` and want to use `mini.notify` with this plugin, you must explicitly declare the dependency to ensure `mini.nvim` is loaded first. It is also recommended to set `lazy = false` for `mini.nvim` to ensure it is configured at startup.
+#### Using the default `vim.notify`
+No configuration is needed. The plugin works out of the box with `vim.notify`.
 
-Here is a complete example for your `lazy.nvim` configuration:
+#### Using `mini.notify`
+To use `mini.notify`, set the `notification_provider` to `'mini.notify'`.
 
+For `lazy.nvim`:
 ```lua
 {
   'sim-maz/show-type.nvim',
   dependencies = { 'echasnovski/mini.nvim' },
-  config = function()
-    require('show_type').setup({
-      notify_func = function(msg)
-        if _G.MiniNotify and _G.MiniNotify.make_notify then
-          local notify = _G.MiniNotify.make_notify()
-          notify(msg, vim.log.levels.INFO, { title = 'Type', timeout = 5000 })
-        else
-          vim.notify(msg, vim.log.levels.INFO, { title = 'Type' })
-        end
-      end
-    })
-  end,
+  opts = {
+    notification_provider = 'mini.notify'
+  }
 }
+```
+**Note:** The `dependencies` key is required for `lazy.nvim` to ensure `mini.nvim` is loaded before this plugin.
+
+#### Using `nvim-notify`
+To use `nvim-notify`, set the `notification_provider` to `'nvim-notify'`.
+
+For `lazy.nvim`:
+```lua
+{
+  'sim-maz/show-type.nvim',
+  dependencies = { 'rcarriga/nvim-notify' },
+  opts = {
+    notification_provider = 'nvim-notify'
+  }
+}
+```
+**Note:** The `dependencies` key is required for `lazy.nvim` to ensure `nvim-notify` is loaded before this plugin.
+
+For other plugin managers:
+```lua
+require('show_type').setup({
+  notification_provider = 'nvim-notify'
+})
 ```
 
 ## Usage
@@ -101,4 +106,4 @@ vim.keymap.set('n', '<Leader>st', '<cmd>ShowType<cr>', { desc = 'Show Type' })
 
 ## How it works
 
-This plugin uses `vim.lsp.buf_request_all` to send a `textDocument/hover` request to the LSP server. This is done without triggering the default hover UI (floating window). It then parses the hover information to extract the type and displays it using the configured notification function.
+This plugin uses `vim.lsp.buf_request_all` to send a `textDocument/hover` request to the LSP server without triggering the default hover UI. It then parses the hover information to extract the type and displays it using the configured notification function.


### PR DESCRIPTION
This commit adds support for `rcarriga/nvim-notify` as a notification provider.

Users can now set `notification_provider = 'nvim-notify'` in the setup options to use `nvim-notify` for displaying type information. The implementation includes a safe-check to fall back to the default `vim.notify` if `nvim-notify` is not available.

The `README.md` has been updated to document this new option and provide configuration examples for `lazy.nvim` and other plugin managers.